### PR TITLE
[Bower] Dependency fix in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "less",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "less.js",
   "dependencies": {
     "require-css": "~0.0.1"


### PR DESCRIPTION
**This fixes**
An error with the dependency to [require-css](https://github.com/guybedford/require-css).

running: 

```
bower install git://github.com/guybedford/require-less.git
```

would previously download [require-css](https://github.com/guybedford/require-css) to a folder named _css_. This is a problem because in the code you [require it](https://github.com/guybedford/require-less/blob/master/less-builder.js#L1) as _../require-css_.

I also shortened the dependency to just version since [require-css](https://github.com/guybedford/require-css) is in the bower registry... hope that's fine by you.
