### PR TITLE
Provide more descriptive error messages for LESS

### DIFF
--- a/less-builder.js
+++ b/less-builder.js
@@ -93,6 +93,7 @@ define(['require', './normalize'], function(req, normalize) {
     });
     parser.parse('@import (multiple) "' + path.relative(baseUrl, fileUrl) + '";', function(err, tree) {
       if (err) {
+        console.log(err + ' at ' + path.relative(baseUrl, err.filename) + ', line ' + err.line);
         return load.error(err);
       }
 


### PR DESCRIPTION
As of now, require-less fails with very cryptic error messages during the build process. This patch logs error information returned from less to the console.
