### PR TITLE
less Parser in less-builder uses requirejs config.less.relativeUrls

### DIFF
--- a/less-builder.js
+++ b/less-builder.js
@@ -89,7 +89,8 @@ define(['require', './normalize'], function(req, normalize) {
       paths: [baseUrl],
       filename: fileUrl,
       async: false,
-      syncImport: true
+      syncImport: true,
+      relativeUrls: config.less && config.less.relativeUrls
     });
     parser.parse('@import (multiple) "' + path.relative(baseUrl, fileUrl) + '";', function(err, tree) {
       if (err) {


### PR DESCRIPTION
I ran into a case where I could manually `lessc --relative-urls` successfully, but setting my requirejs `config.less.relativeUrls = true` would result in a failed build.

Currently when optimizing a file using require-less, the Less parser is not passed any of the options in `config.less`. They are only passed to the `toCSS` method on the parsed tree.

However, there are times when a user needs their config options passed to the Parser. This PR currently only does that for `relativeUrls`, but I'm eager for suggestions on a more general solution.

What do you think?
