### PR TITLE
fixed potentiel exception

### DIFF
--- a/less.js
+++ b/less.js
@@ -42,8 +42,7 @@ define(['require'], function(require) {
   }
 
   lessAPI.load = function(lessId, req, load, config) {
-    if (config.less)
-      window.less = config.less || {};
+    window.less = config.less || {};
     window.less.env = 'development';
 
     require(['./lessc', './normalize'], function(lessc, normalize) {


### PR DESCRIPTION
if config.less is not defined then the line  below will crash.
     window.less.env = 'development';

There is no need for the if (config.less) line as it will be taken care with the config.less || {}
