### PR TITLE
Include provided paths config parameter

### DIFF
--- a/less-builder.js
+++ b/less-builder.js
@@ -93,7 +93,7 @@ define(['require', './normalize'], function(req, normalize) {
 
     //add to the buffer
     var cfg = _config.less || {};
-    cfg.paths = [baseUrl];
+    cfg.paths = [baseUrl].concat(cfg.paths || []);
     cfg.filename = fileUrl;
     cfg.async = false;
     cfg.syncImport = true;


### PR DESCRIPTION
Hi! I noticed require-less will overwrite the "paths" config parameter, making it difficult to import LESS-files from other directories. I hope this edit is good enough - at least it solved our issues.
