### PR TITLE
fix path conversion

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -42,6 +42,20 @@ define(function() {
   // given a relative URI, and two absolute base URIs, convert it from one base to another
   var protocolRegEx = /[^\:\/]*:\/\/([^\/])*/;
   var absUrlRegEx = /^(\/|data:)/;
+
+  // given a URI, remove '..' if possible
+  function normalizeURI(uri) {
+      var val= uri.split('/').reduce(function(prev, curr, idx) {
+          if (curr !== '..' || idx === 0) {
+              prev.push(curr);
+          } else {
+              prev.pop();
+          }
+          return prev;
+      }, []).join('/');
+      return val;
+  }
+
   function convertURIBase(uri, fromBase, toBase) {
     if (uri.match(absUrlRegEx) || uri.match(protocolRegEx))
       return uri;
@@ -113,8 +127,8 @@ define(function() {
   
   var normalizeCSS = function(source, fromBase, toBase) {
 
-    fromBase = removeDoubleSlashes(fromBase);
-    toBase = removeDoubleSlashes(toBase);
+    fromBase = normalizeURI(removeDoubleSlashes(fromBase));
+    toBase = normalizeURI(removeDoubleSlashes(toBase));
 
     var urlRegEx = /@import\s*("([^"]*)"|'([^']*)')|url\s*\(\s*(\s*"([^"]*)"|'([^']*)'|[^\)]*\s*)\s*\)/ig;
     var result, url, source;


### PR DESCRIPTION
fix path conversion when fromBase or toBase contain backtracks.
Same modification as https://github.com/jcppman/require-css/commit/ff30bd1eb2dc238ad48b984af67f79415885b7c2