### PR TITLE
Option to render CSS into component

### DIFF
--- a/less-builder.js
+++ b/less-builder.js
@@ -153,7 +153,8 @@ define(['require', './normalize'], function(req, normalize) {
     if (moduleName.match(absUrlRegEx))
       return;
 
-    layerBuffer.push(lessBuffer[moduleName]);
+    var css = lessBuffer[moduleName];
+    layerBuffer.push(css);
 
     //use global variable to combine plugin results with results of require-css plugin
     if (!global._requirejsCssData) {
@@ -165,10 +166,12 @@ define(['require', './normalize'], function(req, normalize) {
       global._requirejsCssData.usedBy.less = true;
     }
 
-    write.asModule(pluginName + '!' + moduleName, 'define(function(){})');
+    var moduleContent = config.less.component ? "return '" + escape(compress(css)) + "'" : '';
+    write.asModule(pluginName + '!' + moduleName, 'define(function(){' + moduleContent + '});');
   };
 
   lessAPI.onLayerEnd = function(write, data) {
+    if (config.less.component === true) return;
 
     //calculate layer css
     var css = layerBuffer.join('');

--- a/less.js
+++ b/less.js
@@ -1,44 +1,47 @@
-define(['require'], function(require) {
-  
-  var lessAPI = {};
-  
-  lessAPI.pluginBuilder = './less-builder';
-  
+define(function(require) {
+  var lessAPI = {
+    pluginBuilder: './less-builder'
+  };
+
   if (typeof window == 'undefined') {
     lessAPI.load = function(n, r, load) { load(); };
     return lessAPI;
   }
-  
+
   lessAPI.normalize = function(name, normalize) {
-    if (name.substr(name.length - 5, 5) == '.less')
+    if (name.substr(name.length - 5, 5) === '.less') {
       name = name.substr(0, name.length - 5);
+    }
 
-    name = normalize(name);
-
-    return name;
+    return normalize(name);
   };
-  
-  var head = document.getElementsByTagName('head')[0];
 
+  var head = document.getElementsByTagName('head')[0];
   var base = document.getElementsByTagName('base');
+
   base = base && base[0] && base[0] && base[0].href;
+
   var pagePath = (base || window.location.href.split('#')[0].split('?')[0]).split('/');
+
   pagePath[pagePath.length - 1] = '';
   pagePath = pagePath.join('/');
 
   var styleCnt = 0;
   var curStyle;
+
   lessAPI.inject = function(css) {
     if (styleCnt < 31) {
       curStyle = document.createElement('style');
       curStyle.type = 'text/css';
       head.appendChild(curStyle);
-      styleCnt++;
+      styleCnt += 1;
     }
-    if (curStyle.styleSheet)
+
+    if (curStyle.styleSheet) {
       curStyle.styleSheet.cssText += css;
-    else
+    } else {
       curStyle.appendChild(document.createTextNode(css));
+    }
   };
 
   lessAPI.load = function(lessId, req, load, config) {
@@ -46,7 +49,6 @@ define(['require'], function(require) {
     window.less.env = 'development';
 
     require(['./lessc', './normalize'], function(lessc, normalize) {
-
       var fileUrl = req.toUrl(lessId + '.less');
       fileUrl = normalize.absoluteURI(fileUrl, pagePath);
 
@@ -54,12 +56,15 @@ define(['require'], function(require) {
       var generation = (lessc.version || [1])[0];
       var renderer;
       var cssGetter;
+
       if (generation === 1) {
         //v1, use parser and toCSS
         var parser = new lessc.Parser(window.less);
+
         renderer = function (input, cb) {
           parser.parse.call(parser, input, cb, window.less);
         };
+
         cssGetter = function (tree) {
           return tree.toCSS(config.less);
         };
@@ -68,6 +73,7 @@ define(['require'], function(require) {
         renderer = function (input, cb) {
           lessc.render(input, window.less, cb);
         };
+
         cssGetter = function (output) {
           return output.css;
         };
@@ -78,6 +84,7 @@ define(['require'], function(require) {
           console.log(err + ' at ' + fileUrl + ', line ' + err.line);
           return load.error(err);
         }
+
         var css = cssGetter(output);
 
         if (config.less.inject !== false) {
@@ -87,11 +94,9 @@ define(['require'], function(require) {
           load(css);
         }
 
-        setTimeout(load, 7);
       }, window.less);
-
     });
   };
-  
+
   return lessAPI;
 });

--- a/less.js
+++ b/less.js
@@ -79,7 +79,13 @@ define(['require'], function(require) {
           return load.error(err);
         }
         var css = cssGetter(output);
-        lessAPI.inject(normalize(css, fileUrl, pagePath));
+
+        if (config.less.inject !== false) {
+          lessAPI.inject(normalize(css, fileUrl, pagePath));
+          setTimeout(load, 7);
+        } else {
+          load(css);
+        }
 
         setTimeout(load, 7);
       }, window.less);

--- a/less.js
+++ b/less.js
@@ -87,7 +87,7 @@ define(function(require) {
 
         var css = cssGetter(output);
 
-        if (config.less.inject !== false) {
+        if (config.less.component !== true) {
           lessAPI.inject(normalize(css, fileUrl, pagePath));
           setTimeout(load, 7);
         } else {


### PR DESCRIPTION
This PR adds the option `less.component` to the RequireJS config and – if set to `true` – renders the LESS code as CSS into the component where it was required from.

We are currently using this to enable LESS in RactiveJS components.

_Example:_

```js
import Ractive from 'ractive';
import css from 'less!./App';
import template from 'text!./App.html';

const App = Ractive.extend({
  template,
  css
});

export { App };
```

Would be glad if you considered this, please let me know what you think.